### PR TITLE
Group writing for per bookie client

### DIFF
--- a/bookkeeper-server/pom.xml
+++ b/bookkeeper-server/pom.xml
@@ -153,6 +153,14 @@
       <groupId>com.carrotsearch</groupId>
       <artifactId>hppc</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+    </dependency>
     <!-- testing dependencies -->
     <dependency>
       <groupId>org.apache.bookkeeper</groupId>

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/AuthHandler.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/AuthHandler.java
@@ -41,6 +41,7 @@ import org.apache.bookkeeper.auth.ClientAuthProvider;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.proto.BookkeeperProtocol.AuthMessage;
 import org.apache.bookkeeper.util.ByteBufList;
+import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -228,7 +229,7 @@ class AuthHandler {
         final ClientAuthProvider.Factory authProviderFactory;
         ClientAuthProvider authProvider;
         final AtomicLong transactionIdGenerator;
-        final Queue<Object> waitingForAuth = new ConcurrentLinkedQueue<>();
+        final Queue<Pair<Object, ChannelPromise>> waitingForAuth = new ConcurrentLinkedQueue<>();
         final ClientConnectionPeer connectionPeer;
 
         private final boolean isUsingV2Protocol;
@@ -349,7 +350,7 @@ class AuthHandler {
                         super.write(ctx, msg, promise);
                         super.flush(ctx);
                     } else {
-                        waitingForAuth.add(msg);
+                        waitingForAuth.add(Pair.of(msg, promise));
                     }
                 } else if (msg instanceof BookieProtocol.Request) {
                     // let auth messages through, queue the rest
@@ -358,10 +359,10 @@ class AuthHandler {
                         super.write(ctx, msg, promise);
                         super.flush(ctx);
                     } else {
-                        waitingForAuth.add(msg);
+                        waitingForAuth.add(Pair.of(msg, promise));
                     }
                 } else if (msg instanceof ByteBuf || msg instanceof ByteBufList) {
-                    waitingForAuth.add(msg);
+                    waitingForAuth.add(Pair.of(msg, promise));
                 } else {
                     LOG.info("[{}] dropping write of message {}", ctx.channel(), msg);
                 }
@@ -427,10 +428,10 @@ class AuthHandler {
                 if (rc == BKException.Code.OK) {
                     synchronized (this) {
                         authenticated = true;
-                        Object msg = waitingForAuth.poll();
-                        while (msg != null) {
-                            ctx.writeAndFlush(msg);
-                            msg = waitingForAuth.poll();
+                        Pair<Object, ChannelPromise> pair = waitingForAuth.poll();
+                        while (pair != null && pair.getKey() != null) {
+                            ctx.writeAndFlush(pair.getKey(), pair.getValue());
+                            pair = waitingForAuth.poll();
                         }
                     }
                 } else {

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtoEncoding.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtoEncoding.java
@@ -218,8 +218,9 @@ public class BookieProtoEncoding {
 
         public static void serializeAddRequests(Object request, ByteBuf buf) {
             if (request instanceof ByteBuf) {
-                buf.writeBytes((ByteBuf) request);
-                ((ByteBuf) request).release();
+                ByteBuf r = (ByteBuf) request;
+                buf.writeBytes(r);
+                r.release();
             } else if (request instanceof ByteBufList) {
                 ByteBufList list = (ByteBufList) request;
                 list.writeTo(buf);

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtoEncoding.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtoEncoding.java
@@ -215,6 +215,17 @@ public class BookieProtoEncoding {
 
             return masterKey;
         }
+
+        public static void serializeAddRequests(Object request, ByteBuf buf) {
+            if (request instanceof ByteBuf) {
+                buf.writeBytes((ByteBuf) request);
+                ((ByteBuf) request).release();
+            } else if (request instanceof ByteBufList) {
+                ByteBufList list = (ByteBufList) request;
+                list.writeTo(buf);
+                list.release();
+            }
+        }
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtoEncoding.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtoEncoding.java
@@ -28,6 +28,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.ByteBufOutputStream;
+import io.netty.buffer.CompositeByteBuf;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
@@ -216,15 +217,11 @@ public class BookieProtoEncoding {
             return masterKey;
         }
 
-        public static void serializeAddRequests(Object request, ByteBuf buf) {
+        public static void serializeAddRequests(Object request, ByteBufList buf) {
             if (request instanceof ByteBuf) {
-                ByteBuf r = (ByteBuf) request;
-                buf.writeBytes(r);
-                r.release();
+                buf.add((ByteBuf) request);
             } else if (request instanceof ByteBufList) {
-                ByteBufList list = (ByteBufList) request;
-                list.writeTo(buf);
-                list.release();
+                buf.add((ByteBufList) request);
             }
         }
     }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtoEncoding.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/proto/BookieProtoEncoding.java
@@ -28,7 +28,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.ByteBufOutputStream;
-import io.netty.buffer.CompositeByteBuf;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/AuditorCheckAllLedgersTask.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/replication/AuditorCheckAllLedgersTask.java
@@ -267,19 +267,19 @@ public class AuditorCheckAllLedgersTask extends AuditorTask {
                 if (bookies.isEmpty()) {
                     // no missing fragments
                     callback.processResult(BKException.Code.OK, null, null);
-                    return;
+                } else {
+                    publishSuspectedLedgersAsync(bookies.stream().map(BookieId::toString).collect(Collectors.toList()),
+                            Sets.newHashSet(lh.getId())
+                    ).whenComplete((result, cause) -> {
+                        if (null != cause) {
+                            LOG.error("Auditor exception publishing suspected ledger {} with lost bookies {}",
+                                    lh.getId(), bookies, cause);
+                            callback.processResult(BKException.Code.ReplicationException, null, null);
+                        } else {
+                            callback.processResult(BKException.Code.OK, null, null);
+                        }
+                    });
                 }
-                publishSuspectedLedgersAsync(bookies.stream().map(BookieId::toString).collect(Collectors.toList()),
-                        Sets.newHashSet(lh.getId())
-                ).whenComplete((result, cause) -> {
-                    if (null != cause) {
-                        LOG.error("Auditor exception publishing suspected ledger {} with lost bookies {}",
-                                lh.getId(), bookies, cause);
-                        callback.processResult(BKException.Code.ReplicationException, null, null);
-                    } else {
-                        callback.processResult(BKException.Code.OK, null, null);
-                    }
-                });
             } else {
                 callback.processResult(rc, null, null);
             }

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/ByteBufList.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/ByteBufList.java
@@ -111,6 +111,15 @@ public class ByteBufList extends AbstractReferenceCounted {
         return buf;
     }
 
+    public static ByteBufList get(ByteBufList b1) {
+        ByteBufList buf = get();
+        for (int i = 0; i < b1.buffers.size(); ++i) {
+            buf.add(b1.buffers.get(i));
+        }
+        return buf;
+    }
+
+
     /**
      * Get a new {@link ByteBufList} instance from the pool that is the clone of an already existing instance.
      */
@@ -147,6 +156,10 @@ public class ByteBufList extends AbstractReferenceCounted {
         } else {
             buffers.add(unwrapped);
         }
+    }
+
+    public void add(ByteBufList b1) {
+        buffers.addAll(b1.buffers);
     }
 
     /**

--- a/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/ByteBufList.java
+++ b/bookkeeper-server/src/main/java/org/apache/bookkeeper/util/ByteBufList.java
@@ -276,6 +276,13 @@ public class ByteBufList extends AbstractReferenceCounted {
         return res;
     }
 
+    public void writeTo(ByteBuf buf) {
+        for (int i = 0; i < buffers.size(); ++i) {
+            ByteBuf b = buffers.get(i);
+            buf.writeBytes(b, b.readerIndex(), b.readableBytes());
+        }
+    }
+
     @Override
     public ByteBufList retain() {
         super.retain();

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
@@ -123,6 +123,9 @@ public class BookieWriteLedgerTest extends
     @Override
     @Before
     public void setUp() throws Exception {
+        baseConf.setJournalWriteData(writeJournal);
+        baseClientConf.setUseV2WireProtocol(useV2);
+
         super.setUp();
         rng = new Random(0); // Initialize the Random
         // Number Generator
@@ -136,14 +139,12 @@ public class BookieWriteLedgerTest extends
         String ledgerManagerFactory = "org.apache.bookkeeper.meta.HierarchicalLedgerManagerFactory";
         // set ledger manager
         baseConf.setLedgerManagerFactoryClassName(ledgerManagerFactory);
-        baseConf.setJournalWriteData(writeJournal);
         /*
          * 'testLedgerCreateAdvWithLedgerIdInLoop2' testcase relies on skipListSizeLimit,
          * so setting it to some small value for making that testcase lite.
          */
         baseConf.setSkipListSizeLimit(4 * 1024 * 1024);
         baseClientConf.setLedgerManagerFactoryClassName(ledgerManagerFactory);
-        baseClientConf.setUseV2WireProtocol(useV2);
     }
 
     /**

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
@@ -1567,15 +1567,12 @@ public class BookieWriteLedgerTest extends
                 @Override
                 public void addComplete(int rc, LedgerHandle lh, long entryId, Object ctx) {
                     assertEquals(0, rc);
-                    //LOG.info("[hangc] entry: {}, rc: {}", entryId, rc);
                     latch.countDown();
                 }
             }, null);
         }
         latch.await();
 
-        LOG.info("[hangc] send cost: {} ms", System.currentTimeMillis() - start);
-        LOG.info("[hangc] start to read....");
         readEntries(lh, entries);
         lh.close();
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
@@ -134,7 +134,7 @@ public class BookieWriteLedgerTest extends
     }
 
     public BookieWriteLedgerTest() {
-        super(5, 1800);
+        super(5, 180);
         this.digestType = DigestType.CRC32;
         String ledgerManagerFactory = "org.apache.bookkeeper.meta.HierarchicalLedgerManagerFactory";
         // set ledger manager

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
@@ -1556,7 +1556,6 @@ public class BookieWriteLedgerTest extends
         lh = bkc.createLedgerAdv(1, 1, 1, digestType, ledgerPassword);
         numEntriesToWrite = 10000;
         List<byte[]> entries = new ArrayList<>();
-        long start = System.currentTimeMillis();
         CountDownLatch latch = new CountDownLatch(numEntriesToWrite);
         for (int i = 0; i < numEntriesToWrite; ++i) {
             ByteBuffer entry = ByteBuffer.allocate(4);
@@ -1572,7 +1571,6 @@ public class BookieWriteLedgerTest extends
             }, null);
         }
         latch.await();
-
         readEntries(lh, entries);
         lh.close();
 

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/client/BookieWriteLedgerTest.java
@@ -125,7 +125,6 @@ public class BookieWriteLedgerTest extends
     public void setUp() throws Exception {
         baseConf.setJournalWriteData(writeJournal);
         baseClientConf.setUseV2WireProtocol(useV2);
-
         super.setUp();
         rng = new Random(0); // Initialize the Random
         // Number Generator

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
@@ -252,6 +252,10 @@ public abstract class BookKeeperClusterTestCase {
      */
     protected void startBKCluster(String metadataServiceUri) throws Exception {
         baseConf.setMetadataServiceUri(metadataServiceUri);
+        baseConf.setJournalAdaptiveGroupWrites(true);
+        baseConf.setJournalMaxGroupWaitMSec(100);
+        baseConf.setJournalFlushWhenQueueEmpty(false);
+        //baseConf.setJournalWriteData(false);
         baseClientConf.setMetadataServiceUri(metadataServiceUri);
         baseClientConf.setAllocatorPoolingPolicy(PoolingPolicy.UnpooledHeap);
         if (numBookies > 0) {

--- a/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
+++ b/bookkeeper-server/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
@@ -252,10 +252,6 @@ public abstract class BookKeeperClusterTestCase {
      */
     protected void startBKCluster(String metadataServiceUri) throws Exception {
         baseConf.setMetadataServiceUri(metadataServiceUri);
-        baseConf.setJournalAdaptiveGroupWrites(true);
-        baseConf.setJournalMaxGroupWaitMSec(100);
-        baseConf.setJournalFlushWhenQueueEmpty(false);
-        //baseConf.setJournalWriteData(false);
         baseClientConf.setMetadataServiceUri(metadataServiceUri);
         baseClientConf.setAllocatorPoolingPolicy(PoolingPolicy.UnpooledHeap);
         if (numBookies > 0) {

--- a/circe-checksum/pom.xml
+++ b/circe-checksum/pom.xml
@@ -104,17 +104,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.jacoco</groupId>
-        <artifactId>jacoco-maven-plugin</artifactId>
-        <version>${jacoco-maven-plugin.version}</version>
-        <configuration>
-            <excludes>
-                <!-- this class is generated -->
-                <exclude>com/scurrilous/circe/checksum/NarSystem*</exclude>
-            </excludes>
-        </configuration>
-       </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -196,7 +196,7 @@
     <maven-deploy-plugin.version>2.7</maven-deploy-plugin.version>
     <maven-install-plugin.version>2.5.1</maven-install-plugin.version>
     <maven-jar-plugin.version>3.2.2</maven-jar-plugin.version>
-    <maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
+    <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
     <maven-shade-plugin.version>3.2.0</maven-shade-plugin.version>
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
     <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -830,14 +830,6 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
-    </dependency>
-    <dependency>
       <groupId>commons-configuration</groupId>
       <artifactId>commons-configuration</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,6 @@
     <gmavenplus-plugin.version>1.13.1</gmavenplus-plugin.version>
     <license-maven-plugin.version>1.6</license-maven-plugin.version>
     <lombok-maven-plugin.version>1.18.20.0</lombok-maven-plugin.version>
-    <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
     <maven-antrun-plugin.version>1.8</maven-antrun-plugin.version>
     <maven-assembly-plugin.version>3.1.0</maven-assembly-plugin.version>
     <maven-checkstyle-plugin.version>3.2.1</maven-checkstyle-plugin.version>
@@ -1109,54 +1108,6 @@
     </plugins>
   </build>
   <profiles>
-    <profile>
-      <!-- profile used by jenkins CI -->
-      <id>code-coverage</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.eluder.coveralls</groupId>
-            <artifactId>coveralls-maven-plugin</artifactId>
-            <version>${coveralls-maven-plugin.version}</version>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <version>${maven-surefire-plugin.version}</version>
-            <configuration>
-              <!-- @{argLine} is a variable injected by JaCoCo-->
-              <argLine>@{argLine} -Xmx2G -Djava.net.preferIPv4Stack=true -Dio.netty.leakDetection.level=paranoid</argLine>
-              <redirectTestOutputToFile>${redirectTestOutputToFile}</redirectTestOutputToFile>
-              <forkCount>${forkCount.variable}</forkCount>
-              <reuseForks>false</reuseForks>
-              <trimStackTrace>false</trimStackTrace>
-              <forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
-              <rerunFailingTestsCount>${testRetryCount}</rerunFailingTestsCount>
-            </configuration>
-          </plugin>
-          <plugin>
-            <groupId>org.jacoco</groupId>
-            <artifactId>jacoco-maven-plugin</artifactId>
-            <version>${jacoco-maven-plugin.version}</version>
-            <executions>
-              <execution>
-                <id>pre-test</id>
-                <goals>
-                  <goal>prepare-agent</goal>
-                </goals>
-              </execution>
-              <execution>
-                <id>post-test</id>
-                <phase>test</phase>
-                <goals>
-                  <goal>report</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
     <profile>
       <id>owasp-dependency-check</id>
       <build>

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
     <grpc.version>1.47.0</grpc.version>
     <guava.version>31.0.1-jre</guava.version>
     <kerby.version>1.1.1</kerby.version>
-    <hadoop.version>3.3.4</hadoop.version>
+    <hadoop.version>3.3.5</hadoop.version>
     <hamcrest.version>1.3</hamcrest.version>
     <hdrhistogram.version>2.1.10</hdrhistogram.version>
     <jackson.version>2.13.4.20221013</jackson.version>

--- a/testtools/pom.xml
+++ b/testtools/pom.xml
@@ -25,4 +25,15 @@
     <artifactId>testtools</artifactId>
     <name>Apache BookKeeper :: Test Tools</name>
     <version>4.16.0-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+        </dependency>
+    </dependencies>
 </project>


### PR DESCRIPTION
### Motivation
When the BookKeeper client writes an entry to the BookKeeper server, it runs with the following steps:
- Step 1: Initiate a PendingAddOp object.
- Step 2: For each replica, select a bookie client channel according to the ledgerId
- Step 3: Write the entry to the bookie client channel, and flush it.
- Step 4: The entry was added to Netty's pending queue, and processed with the configured Netty pipeline, such as `bookieProtoEncoder`,  `lengthbasedframedecoder`, and `consolidation`
- Step 5: Waiting for the written response

If the bookie client writes small entries with high ops and the Netty's pending queue will be full and the Netty thread will be busy with processing entries and flushing them into the socket channel. The CPU will switch between the user mode and the kernel mode in high frequency.

#3383 introduced Netty channel flushes consolidation to mitigate syscall overhead. But it can not reduce the overhead on the Netty threads. 

We can tune it one `Step 3` to group the small entries into one ByteBuf and flush it into the Netty pending queue when conditions are met.

### Design
When a new entry comes to the bookie client channel, we add it into one ByteBuf and check whether the ByteBuf exceeds the max threshold, the default is 1MB. 

In order to avoid entry staying in the Bookie client channel ByteBuf for a long time causing high write latency, we schedule a timer task to flush the ByteBuf every 1 ms.

### Performance
We test the write performance on my laptop with the following command.
```bash
bin/benchmark writes -ensemble 1 -quorum 1 -ackQuorum 1 -ledgers 100 -throttle 300000 -entrysize 60 -useV2 -warmupMessages 1000000
```
The performance result.
|  Writer ledgers | batched write ops/s | non-batched write ops/s | improved |
| --- | --- | --- | --- | 
| 1 | 333238 | 335970 | 0% |
| 50 | 261605 | 153011 |  71% |
| 100 | 260650 | 126331 |  100% |
| 500 | 265628 | 164393 | 62%  |